### PR TITLE
[FIX] PolicyListResponse에서 policy_id 타입 변경 (int → str) + 테스트코드 반영

### DIFF
--- a/app/schemas/policy/policy.py
+++ b/app/schemas/policy/policy.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 
 class PolicyListResponse(BaseModel):
     # 정책 ID
-    policy_id: int
+    policy_id: str
     
     # 상시 / 마감 / 예정
     status: str

--- a/tests/test_mock_api.py
+++ b/tests/test_mock_api.py
@@ -131,7 +131,7 @@ def test_policy_list_with_mock_data():
     assert len(result["youthPolicyList"]) == 1
     policy = result["youthPolicyList"][0]
 
-    assert policy["policy_id"] == 501
+    assert policy["policy_id"] == "501"
     assert policy["title"] == "모크 청년 도약 자금"
     assert policy["status"].startswith("마감 D-")
     assert "청년" in policy["keyword"]


### PR DESCRIPTION
## #️⃣ Issue Number

#27 

## 📝작업 내용

[FIX] PolicyListResponse에서 policy_id 타입 변경 (int → str) + 테스트코드 반영

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

<img width="1198" height="1069" alt="image" src="https://github.com/user-attachments/assets/5069d89d-1f7e-47a9-b53d-9ca8c726bd14" />


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트 혹은 테스트 코드를 작성했습니다.