### PR TITLE
[FIX] update summary_raw field to use plcyExplnCn instead of plcyCn

### DIFF
--- a/app/elt/policy/04_stg_to_core.py
+++ b/app/elt/policy/04_stg_to_core.py
@@ -147,7 +147,7 @@ def normalize_row(row: Dict[str, Any]) -> NormalizedPolicy:
     ext_id = row["policy_id"]
     ext_source = ETL_SOURCE
     title = raw_json.get("plcyNm", "")
-    summary_raw = raw_json.get("plcyCn", "")
+    summary_raw = raw_json.get("plcyExplnCn", "")
     description_raw = raw_json.get("plcySprtCn", "")
     summary_ai = ai_summary(raw_json)
     # status = set_policy_status(raw_json.get("aplyPrdSeCd", ""), raw_json.get("aplyYmd", "")) # status는 update_policy_status.py에서 별도 처리


### PR DESCRIPTION
## #️⃣ Issue Number

#31 

## 📝작업 내용

summary_raw 아무 값도 생성 안 되는 문제 해결

summary_raw = raw_json.get("plcyCn", "") -> .get("plcyExplnCn", "")


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트 혹은 테스트 코드를 작성했습니다.